### PR TITLE
Fix rspec gem in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,6 @@ group :development, :test do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 
-  gem 'rspec', '3.3.0'
+  gem 'rspec-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,10 +105,6 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     rdoc (4.2.0)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
     rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
     rspec-expectations (3.3.1)
@@ -116,6 +112,14 @@ GEM
       rspec-support (~> 3.3.0)
     rspec-mocks (3.3.2)
       diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-rails (3.3.3)
+      actionpack (>= 3.0, < 4.3)
+      activesupport (>= 3.0, < 4.3)
+      railties (>= 3.0, < 4.3)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
     sass (3.4.16)
@@ -161,10 +165,13 @@ DEPENDENCIES
   jquery-rails
   mysql2
   rails (= 4.2.1)
-  rspec (= 3.3.0)
+  rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.10.5


### PR DESCRIPTION
**Context:** the Gemfile had an `rspec` gem added and the correct gem we should use is the `rspec-rails` gem. Removed the old gem and added the new one.

**Usage:** update the code and run `bundle`. This should install the gem, generating the empty `spec` directory. Then run `bundle exec db:migrate` and `bundle exec db:test:prepare` to take the development and test databases where they need to be, so that the `rake spec` (alternatively, just `rake`) command works correctly to run the test suite.