### PR TITLE
Add name to subject model

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/app/models/Student.rb
+++ b/app/models/Student.rb
@@ -1,2 +1,2 @@
-class Student
+class Student < ActiveRecord::Base
 end

--- a/app/models/Subject.rb
+++ b/app/models/Subject.rb
@@ -1,3 +1,3 @@
-class Subject
+class Subject < ActiveRecord::Base
   has_many :subjects
 end

--- a/db/migrate/20150720021243_add_name_to_subject.rb
+++ b/db/migrate/20150720021243_add_name_to_subject.rb
@@ -1,0 +1,5 @@
+class AddNameToSubject < ActiveRecord::Migration
+  def change
+    add_column :subjects, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150718155748) do
+ActiveRecord::Schema.define(version: 20150720021243) do
 
   create_table "students", force: :cascade do |t|
     t.integer "passed_subject_id", limit: 4
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20150718155748) do
 
   create_table "subjects", force: :cascade do |t|
     t.integer "correlative_id", limit: 4
+    t.string  "name",           limit: 255
   end
 
 end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe Subject do
   it 'has a name' do
-    expect(Subject.new(name: 'Algebra').name).to be('Algebra')
+    expect(Subject.new(name: 'Algebra').name).to eq('Algebra')
   end
 end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Subject do
+  it 'has a name' do
+    expect(Subject.new(name: 'Algebra').name).to be('Algebra')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,52 @@
+# This file is copied to spec/ when you run 'rails generate rspec:install'
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../../config/environment', __FILE__)
+# Prevent database truncation if the environment is production
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require 'spec_helper'
+require 'rspec/rails'
+# Add additional requires below this line. Rails is not loaded until this point!
+
+# Requires supporting ruby files with custom matchers and macros, etc, in
+# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
+# run as spec files by default. This means that files in spec/support that end
+# in _spec.rb will both be required and run as specs, causing the specs to be
+# run twice. It is recommended that you do not name files matching this glob to
+# end with _spec.rb. You can configure this pattern with the --pattern
+# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
+#
+# The following line is provided for convenience purposes. It has the downside
+# of increasing the boot-up time by auto-requiring all files in the support
+# directory. Alternatively, in the individual `*_spec.rb` files, manually
+# require only the support files necessary.
+#
+# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+
+# Checks for pending migrations before tests are run.
+# If you are not using ActiveRecord, you can remove this line.
+ActiveRecord::Migration.maintain_test_schema!
+
+RSpec.configure do |config|
+  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+
+  # If you're not using ActiveRecord, or you'd prefer not to run each of your
+  # examples within a transaction, remove the following line or assign false
+  # instead of true.
+  config.use_transactional_fixtures = true
+
+  # RSpec Rails can automatically mix in different behaviours to your tests
+  # based on their file location, for example enabling you to call `get` and
+  # `post` in specs under `spec/controllers`.
+  #
+  # You can disable this behaviour by removing the line below, and instead
+  # explicitly tag your specs with their type, e.g.:
+  #
+  #     RSpec.describe UsersController, :type => :controller do
+  #       # ...
+  #     end
+  #
+  # The different available types are documented in the features, such as in
+  # https://relishapp.com/rspec/rspec-rails/docs
+  config.infer_spec_type_from_file_location!
+end


### PR DESCRIPTION
**Context:** I run the command `rails generate rspec:install` that automatically generates the needed `rails_helper.rb` file in the `spec` directory, to start adding `rspec` tests. I renamed it to `spec_helper` because that's how I'm used to see it (kind of a convention).

After that, I wrote a failing test to test for the name of a `Subject` instance, that was missing in the original design of the model. That test was fixed by adding a new migration that added the missing column to the table.